### PR TITLE
Improve import dialog UI

### DIFF
--- a/packages/element-ui/src/components/import/ImportSteps.vue
+++ b/packages/element-ui/src/components/import/ImportSteps.vue
@@ -1,132 +1,424 @@
 <template>
-  <el-dialog :model-value="visible" width="700px" @close="close">
-    <template #title>批量导入</template>
-    <el-steps :active="step" align-center class="mb-20">
-      <el-step title="选择文件" />
-      <el-step title="预览数据" />
-      <el-step title="字段映射" />
-      <el-step title="完成" />
-    </el-steps>
-    <div class="step-body">
-      <StepSelectFile v-if="step===0" :columns="columns" :table-title="tableTitle" @select-file="handleFile" @download-template="downloadTemplate" />
-      <StepPreviewData v-if="step===1" :excel-data="excelData" :sheets="sheets" :selected-sheet="sheet" @change-sheet="changeSheet" />
-      <StepImportSettings v-if="step===2" :excel-data="excelData" :columns="columns" :column-mapping="mapping" @update-mapping="val => mapping = val" />
-      <StepImportData v-if="step===3" :status="importStatus" :total="excelData.length" :success="success" :fail="fail" :warnings="warnings" />
+  <el-dialog
+    v-model="dialogVisible"
+    :title="title"
+    width="800px"
+    :close-on-click-modal="false"
+    :destroy-on-close="true"
+    @closed="onClose"
+  >
+    <div class="import-steps">
+      <el-steps :active="activeStep" finish-status="success" simple class="mb-20px">
+        <el-step title="选择EXCEL表" />
+        <el-step title="数据预览" />
+        <el-step title="导入设置" />
+        <el-step title="导入数据" />
+      </el-steps>
+
+      <div class="step-content">
+        <!-- 步骤1: 选择EXCEL表 -->
+        <StepSelectFile
+          v-if="activeStep === 0"
+          :columns="columns"
+          :table-title="tableTitle"
+          @select-file="handleFileSelected"
+          @download-template="handleDownloadTemplate"
+        />
+
+        <!-- 步骤2: 数据预览 -->
+        <StepPreviewData
+          v-if="activeStep === 1"
+          :excel-data="excelData"
+          :sheets="excelSheets"
+          :selected-sheet="selectedSheet"
+          @change-sheet="handleSheetChange"
+        />
+
+        <!-- 步骤3: 导入设置 -->
+        <StepImportSettings
+          v-if="activeStep === 2"
+          :excel-data="excelData"
+          :columns="columns"
+          :column-mapping="columnMapping"
+          @update-mapping="handleUpdateMapping"
+        />
+
+        <!-- 步骤4: 导入数据 -->
+        <StepImportData
+          v-if="activeStep === 3"
+          :status="importStatus"
+          :total="importTotal"
+          :success="importSuccess"
+          :fail="importFail"
+          :warnings="importWarnings"
+        />
+      </div>
     </div>
+
     <template #footer>
-      <el-button v-if="step>0" @click="prev">上一步</el-button>
-      <el-button v-if="step<3" type="primary" :disabled="nextDisabled" @click="next">下一步</el-button>
-      <el-button v-else type="primary" @click="doImport" :disabled="importStatus==='importing'">开始导入</el-button>
-      <el-button @click="close">关闭</el-button>
+      <div class="dialog-footer">
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button v-if="activeStep > 0" @click="prevStep">上一步</el-button>
+        <el-button 
+          v-if="activeStep < 3" 
+          type="primary" 
+          :disabled="!canGoNext"
+          @click="nextStep"
+        >
+          下一步
+        </el-button>
+        <el-button 
+          v-if="activeStep === 3 && importStatus === 'success'"
+          type="primary" 
+          @click="dialogVisible = false"
+        >
+          完成
+        </el-button>
+      </div>
     </template>
   </el-dialog>
 </template>
 
 <script lang="ts" setup>
 import { ref, computed } from 'vue'
-import * as XLSX from 'xlsx'
 import StepSelectFile from './StepSelectFile.vue'
 import StepPreviewData from './StepPreviewData.vue'
 import StepImportSettings from './StepImportSettings.vue'
 import StepImportData from './StepImportData.vue'
+import * as XLSX from 'xlsx'
+import { ElMessage } from 'element-plus'
 
 defineOptions({ name: 'ImportSteps' })
 
+// 定义组件接受的参数
 const props = defineProps({
-  visible: { type: Boolean, default: false },
-  columns: { type: Array, required: true },
-  tableTitle: { type: String, default: '' }
+  modelValue: {
+    type: Boolean,
+    default: false
+  },
+  columns: {
+    type: Array,
+    required: true
+  },
+  tableTitle: {
+    type: String,
+    default: ''
+  },
+  onImport: {
+    type: Function,
+    required: true
+  }
 })
 
-const emit = defineEmits(['update:visible', 'done'])
+// 定义组件事件
+const emit = defineEmits(['update:modelValue', 'imported'])
 
-const step = ref(0)
-const file = ref(null)
-const sheets = ref([])
-const sheet = ref('')
-const excelData = ref([])
-const mapping = ref({})
-const importStatus = ref('idle')
-const success = ref(0)
-const fail = ref(0)
-const warnings = ref([])
-
-const nextDisabled = computed(() => {
-  if (step.value === 0) return !file.value
-  if (step.value === 1) return excelData.value.length === 0
-  if (step.value === 2) return Object.keys(mapping.value).length === 0
-  return false
+// 对话框可见性
+const dialogVisible = computed({
+  get: () => props.modelValue,
+  set: (val) => emit('update:modelValue', val)
 })
 
-const handleFile = (f) => {
-  file.value = f
-  readFile()
+// 对话框标题
+const title = computed(() => `批量导入${props.tableTitle || '数据'}`)
+
+// 当前激活的步骤
+const activeStep = ref(0)
+
+// Excel相关数据
+const excelFile = ref<File | null>(null)
+const excelData = ref<any[]>([])
+const excelSheets = ref<string[]>([])
+const selectedSheet = ref('')
+
+// 映射关系
+const columnMapping = ref<Record<string, string>>({})
+
+// 导入状态和结果
+const importStatus = ref<'idle' | 'importing' | 'success' | 'error'>('idle')
+const importTotal = ref(0)
+const importSuccess = ref(0)
+const importFail = ref(0)
+const importWarnings = ref<string[]>([])
+
+// 是否可以进入下一步
+const canGoNext = computed(() => {
+  switch (activeStep.value) {
+    case 0:
+      return !!excelFile.value
+    case 1:
+      return excelData.value.length > 0
+    case 2:
+      return Object.keys(columnMapping.value).length > 0
+    default:
+      return true
+  }
+})
+
+// 上一步
+const prevStep = () => {
+  if (activeStep.value > 0) {
+    activeStep.value--
+  }
 }
 
-const readFile = () => {
+// 下一步
+const nextStep = async () => {
+  if (activeStep.value < 3) {
+    if (activeStep.value === 2) {
+      importStatus.value = 'importing'
+      startImport()
+    }
+    activeStep.value++
+  }
+}
+
+// 处理文件选择
+const handleFileSelected = async (file: File) => {
+  excelFile.value = file
+  try {
+    const arrayBuffer = await file.arrayBuffer()
+    const data = new Uint8Array(arrayBuffer)
+
+    const readOpts = {
+      type: 'array',
+      raw: true,
+      cellDates: true,
+      cellStyles: true,
+      cellNF: true,
+      dateNF: 'yyyy-mm-dd',
+      sheetStubs: true,
+      WTF: true
+    }
+
+    const workbook = XLSX.read(data, readOpts)
+    if (!workbook || !workbook.SheetNames || workbook.SheetNames.length === 0) {
+      throw new Error('无效的Excel文件结构')
+    }
+
+    excelSheets.value = workbook.SheetNames
+    selectedSheet.value = workbook.SheetNames[0]
+
+    const sheetName = selectedSheet.value
+    const worksheet = workbook.Sheets[sheetName]
+
+    if (!worksheet) {
+      throw new Error(`无法获取工作表: ${sheetName}`)
+    }
+
+    let allData = XLSX.utils.sheet_to_json(worksheet, {
+      header: 1,
+      defval: '',
+      blankrows: false
+    })
+
+    if (!allData || allData.length === 0) {
+      throw new Error('Excel文件为空或格式不正确')
+    }
+
+    const headers = allData[0]
+
+    if (Array.isArray(headers)) {
+      excelData.value = allData.slice(1).map(row => {
+        const obj: Record<string, any> = {}
+        headers.forEach((header, index) => {
+          if (header) {
+            obj[header] = Array.isArray(row) && index < row.length ? row[index] : ''
+          }
+        })
+        return obj
+      })
+    } else {
+      excelData.value = XLSX.utils.sheet_to_json(worksheet, {
+        defval: '',
+        blankrows: false
+      })
+    }
+
+    if (!excelData.value || excelData.value.length === 0) {
+      throw new Error('无法从Excel提取有效数据')
+    }
+
+    createInitialMapping()
+  } catch (error: any) {
+    excelData.value = []
+    ElMessage.error('解析Excel文件失败: ' + (error.message || '未知错误'))
+  }
+}
+
+// 创建初始字段映射关系
+const createInitialMapping = () => {
+  if (excelData.value.length === 0) return
+  const firstRow = excelData.value[0]
+  const mapping: Record<string, string> = {}
+
+  for (const excelCol in firstRow) {
+    const matchedColumn = props.columns.find((col: any) => {
+      return col.label === excelCol || (col.rule && col.rule[0] && col.rule[0].field === excelCol)
+    })
+
+    if (matchedColumn) {
+      mapping[excelCol] = matchedColumn.rule[0].field
+    }
+  }
+
+  columnMapping.value = mapping
+}
+
+// 切换Sheet
+const handleSheetChange = (sheet: string) => {
+  selectedSheet.value = sheet
+  if (!excelFile.value) return
+
   const reader = new FileReader()
   reader.onload = (e) => {
-    const data = new Uint8Array(e.target.result)
-    const workbook = XLSX.read(data, { type: 'array' })
-    sheets.value = workbook.SheetNames
-    sheet.value = workbook.SheetNames[0]
-    parseSheet(workbook)
-    step.value = 1
-  }
-  reader.readAsArrayBuffer(file.value)
-}
-
-const parseSheet = (workbook) => {
-  const ws = workbook.Sheets[sheet.value]
-  excelData.value = XLSX.utils.sheet_to_json(ws, { defval: '' })
-}
-
-const changeSheet = (s) => {
-  sheet.value = s
-  const workbook = XLSX.read(file.value, { type: 'array' })
-  parseSheet(workbook)
-}
-
-const next = () => { if (step.value < 3) step.value++ }
-const prev = () => { if (step.value > 0) step.value-- }
-
-const doImport = () => {
-  importStatus.value = 'importing'
-  setTimeout(() => {
-    const data = excelData.value.map(row => {
-      const item = {}
-      for (const [excelCol, field] of Object.entries(mapping.value)) {
-        if (field) item[field] = row[excelCol]
+    if (!e.target || !e.target.result) return
+    try {
+      const data = new Uint8Array(e.target.result as ArrayBuffer)
+      const readOpts = {
+        type: 'array',
+        raw: true,
+        cellDates: true,
+        cellStyles: true,
+        cellNF: true,
+        dateNF: 'yyyy-mm-dd',
+        sheetStubs: true,
+        WTF: true
       }
-      return item
-    })
-    success.value = data.length
-    fail.value = 0
-    warnings.value = []
-    importStatus.value = 'success'
-    emit('done', data)
-  }, 1000)
+      const workbook = XLSX.read(data, readOpts)
+      const worksheet = workbook.Sheets[sheet]
+      if (!worksheet) {
+        throw new Error(`无法获取工作表: ${sheet}`)
+      }
+      let allData = XLSX.utils.sheet_to_json(worksheet, {
+        header: 1,
+        defval: '',
+        blankrows: false
+      })
+      if (!allData || allData.length === 0) {
+        throw new Error('Excel工作表为空或格式不正确')
+      }
+      const headers = allData[0]
+      if (Array.isArray(headers)) {
+        excelData.value = allData.slice(1).map(row => {
+          const obj: Record<string, any> = {}
+          headers.forEach((header, index) => {
+            if (header) {
+              obj[header] = Array.isArray(row) && index < row.length ? row[index] : ''
+            }
+          })
+          return obj
+        })
+      } else {
+        excelData.value = XLSX.utils.sheet_to_json(worksheet, {
+          defval: '',
+          blankrows: false
+        })
+      }
+      if (!excelData.value || excelData.value.length === 0) {
+        throw new Error('无法从Excel工作表提取有效数据')
+      }
+      createInitialMapping()
+    } catch (error: any) {
+      excelData.value = []
+      ElMessage.error('切换Excel工作表失败: ' + (error.message || '未知错误'))
+    }
+  }
+  reader.onerror = () => {
+    ElMessage.error('读取Excel文件失败')
+  }
+  reader.readAsArrayBuffer(excelFile.value as File)
 }
 
-const downloadTemplate = () => {
-  const headers = props.columns.map(c => c.label)
-  const ws = XLSX.utils.aoa_to_sheet([headers])
+// 更新字段映射
+const handleUpdateMapping = (mapping: Record<string, string>) => {
+  columnMapping.value = mapping
+}
+
+// 处理模板下载
+const handleDownloadTemplate = () => {
   const wb = XLSX.utils.book_new()
-  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1')
-  XLSX.writeFile(wb, props.tableTitle || 'template.xlsx')
+  const headers = props.columns.map((col: any) => col.label)
+  const ws = XLSX.utils.aoa_to_sheet([headers])
+  XLSX.utils.book_append_sheet(wb, ws, '导入模板')
+  XLSX.writeFile(wb, `${props.tableTitle || '数据'}导入模板.xlsx`)
 }
 
-const close = () => {
-  emit('update:visible', false)
-  step.value = 0
-  file.value = null
+// 开始导入过程
+const startImport = async () => {
+  importTotal.value = excelData.value.length
+  importSuccess.value = 0
+  importFail.value = 0
+  importWarnings.value = []
+  try {
+    const transformedData = excelData.value.map(row => {
+      const result: Record<string, any> = {}
+      for (const excelCol in row) {
+        const fieldName = columnMapping.value[excelCol]
+        if (fieldName) {
+          result[fieldName] = row[excelCol]
+        }
+      }
+      return result
+    })
+
+    props.columns.forEach((col: any) => {
+      const field = col.rule && col.rule[0]
+      if (field && field.$required) {
+        transformedData.forEach((row, index) => {
+          if (row[field.field] === undefined || row[field.field] === '') {
+            importWarnings.value.push(`第${index + 1}行缺少必填字段: ${col.label}`)
+          }
+        })
+      }
+    })
+
+    await props.onImport(transformedData)
+    importSuccess.value = transformedData.length
+    importStatus.value = 'success'
+  } catch (error) {
+    importFail.value = importTotal.value
+    importStatus.value = 'error'
+  }
+}
+
+// 关闭对话框时重置状态
+const onClose = () => {
+  activeStep.value = 0
+  excelFile.value = null
   excelData.value = []
-  mapping.value = {}
+  excelSheets.value = []
+  selectedSheet.value = ''
+  columnMapping.value = {}
   importStatus.value = 'idle'
+  importTotal.value = 0
+  importSuccess.value = 0
+  importFail.value = 0
+  importWarnings.value = []
+
+  if (importStatus.value === 'success') {
+    emit('imported', {
+      success: importSuccess.value,
+      fail: importFail.value,
+      warnings: importWarnings.value
+    })
+  }
 }
 </script>
 
 <style scoped>
-.mb-20 { margin-bottom: 20px; }
-.step-body { min-height: 380px; }
+.import-steps {
+  padding: 0 20px;
+}
+.import-steps .mb-20px {
+  margin-bottom: 20px;
+}
+.import-steps .step-content {
+  min-height: 300px;
+}
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
 </style>

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -17,7 +17,11 @@
                    @click="addRaw(true)"><i class="fc-icon icon-add-circle" style="font-weight: 700;"></i>
             {{ formCreateInject.t('add') || '添加' }}
         </el-button>
-        <ImportSteps v-model:visible="showImport" :columns="columns" @done="handleImportDone" />
+        <ImportSteps
+            v-model="showImport"
+            :columns="columns"
+            :on-import="handleImport"
+        />
     </div>
 </template>
 
@@ -106,16 +110,22 @@ export default {
             this.$emit('batch-import');
         },
         batchExport() {
-            const ws = XLSX.utils.json_to_sheet(this.modelValue || []);
+            const headers = this.columns.map(c => c.label);
+            const fields = this.columns.map(c => c.rule && c.rule[0] && c.rule[0].field);
+            const data = [headers];
+            (this.modelValue || []).forEach(row => {
+                data.push(fields.map(f => row[f] !== undefined ? row[f] : ''));
+            });
+            const ws = XLSX.utils.aoa_to_sheet(data);
             const wb = XLSX.utils.book_new();
             XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
             XLSX.writeFile(wb, 'export.xlsx');
             this.$emit('batch-export', this.modelValue);
         },
-        handleImportDone(data) {
+        handleImport(data) {
             this.$emit('update:modelValue', data);
             this.$emit('change', data);
-            this.showImport = false;
+            return Promise.resolve();
         },
         updateValue() {
             const value = this.trs.map((tr, idx) => {
@@ -362,10 +372,11 @@ export default {
 }
 
 ._fc-tf-table {
-    width: 100%;
+    min-width: 100%;
+    width: max-content;
     height: 100%;
     overflow: hidden;
-    table-layout: fixed;
+    table-layout: auto;
     border: 1px solid #EBEEF5;
     border-bottom: 0 none;
 }
@@ -397,8 +408,8 @@ export default {
     position: relative;
     box-sizing: border-box;
     overflow-wrap: break-word;
-    /*white-space: nowrap;*/
-    overflow: hidden;
+    white-space: nowrap;
+    overflow: visible;
     border: 0 none;
     border-bottom: 1px solid #EBEEF5;
 }


### PR DESCRIPTION
## Summary
- update ImportSteps component with better step UI and new props
- adapt TableForm to new ImportSteps API
- fix export to use column headers
- tweak table layout so wide columns scroll horizontally

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683a172a0ddc8326b54fb574a7d79fb5