### PR TITLE
Remove TS and add manual steps

### DIFF
--- a/packages/element-ui/src/components/import/steps/StepImportData.vue
+++ b/packages/element-ui/src/components/import/steps/StepImportData.vue
@@ -55,7 +55,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup>
 import { CircleCheck, CircleClose, Loading } from '@element-plus/icons-vue'
 
 defineOptions({ name: 'StepImportData' })

--- a/packages/element-ui/src/components/import/steps/StepImportSettings.vue
+++ b/packages/element-ui/src/components/import/steps/StepImportSettings.vue
@@ -49,7 +49,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 
 defineOptions({ name: 'StepImportSettings' })

--- a/packages/element-ui/src/components/import/steps/StepPreviewData.vue
+++ b/packages/element-ui/src/components/import/steps/StepPreviewData.vue
@@ -53,7 +53,7 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup>
 import { ref, computed, watch } from 'vue'
 
 defineOptions({ name: 'StepPreviewData' })

--- a/packages/element-ui/src/components/import/steps/StepSelectFile.vue
+++ b/packages/element-ui/src/components/import/steps/StepSelectFile.vue
@@ -51,11 +51,10 @@
   </div>
 </template>
 
-<script lang="ts" setup>
+<script setup>
 import { ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { UploadFilled, Download } from '@element-plus/icons-vue'
-import type { UploadProps, UploadUserFile } from 'element-plus'
 
 defineOptions({ name: 'StepSelectFile' })
 
@@ -68,7 +67,7 @@ const emit = defineEmits(['select-file', 'download-template'])
 
 const fileList = ref([])
 
-const beforeUpload: UploadProps['beforeUpload'] = (file) => {
+const beforeUpload = (file) => {
   const isExcel = file.type === 'application/vnd.ms-excel' ||
     file.type === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
     /(\.xls|\.xlsx)$/.test(file.name.toLowerCase())
@@ -78,12 +77,12 @@ const beforeUpload: UploadProps['beforeUpload'] = (file) => {
   return true
 }
 
-const handleFileChange: UploadProps['onChange'] = (uploadFile) => {
+const handleFileChange = (uploadFile) => {
   fileList.value = [uploadFile.raw]
   emit('select-file', uploadFile.raw)
 }
 
-const handleExceed: UploadProps['onExceed'] = () => {
+const handleExceed = () => {
   ElMessage.warning('只能上传一个文件，请先删除已上传的文件')
 }
 


### PR DESCRIPTION
## Summary
- drop TypeScript setup in import step components
- implement a hand‑written steps bar in `ImportSteps.vue`
- convert TypeScript code to JavaScript

## Testing
- `npx eslint packages/element-ui/src/components/import/ImportSteps.vue` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_b_683ac87f9ecc832684fde184be8fe201