### PR TITLE
Add min/max width options

### DIFF
--- a/packages/ant-design-vue/src/components/FcDesigner.vue
+++ b/packages/ant-design-vue/src/components/FcDesigner.vue
@@ -1566,6 +1566,8 @@ export default defineComponent({
                 let formData = {
                     formCreateChild: '' + rule?.children[0],
                     'formCreateWrap>labelCol>style>width': '',
+                    'formCreateStyle>minWidth': '',
+                    'formCreateStyle>maxWidth': '',
                 };
                 const appendConfigData = configRef.value.appendConfigData;
                 if (is.Function(appendConfigData)) {

--- a/packages/ant-design-vue/src/config/base/field.js
+++ b/packages/ant-design-vue/src/config/base/field.js
@@ -23,6 +23,18 @@ export default function field({t}) {
             value: '',
             title: t('form.labelCol'),
         }, {
+            type: 'SizeInput',
+            field: 'formCreateStyle>minWidth',
+            col: {show: false},
+            value: '',
+            title: t('form.minWidth'),
+        }, {
+            type: 'SizeInput',
+            field: 'formCreateStyle>maxWidth',
+            col: {show: false},
+            value: '',
+            title: t('form.maxWidth'),
+        }, {
             type: 'Struct',
             field: '_control',
             name: 'control',

--- a/packages/ant-design-vue/src/locale/en.js
+++ b/packages/ant-design-vue/src/locale/en.js
@@ -16,6 +16,8 @@ const En = {
         labelWrap: 'Allow labels to wrap',
         colon: 'Whether to display the colon after the label',
         labelCol: 'Label width',
+        minWidth: 'Min width',
+        maxWidth: 'Max width',
         hideRequiredMark: 'Hide red asterisks next to labels for required fields',
         formItemMarginBottom: 'Bottom margin of form items',
         scrollToFirstError: 'Automatically scroll to the first error field if submission fails',

--- a/packages/ant-design-vue/src/locale/zh-cn.js
+++ b/packages/ant-design-vue/src/locale/zh-cn.js
@@ -16,6 +16,8 @@ const ZhCn = {
         labelWrap: '允许标签换行',
         colon: '是否显示标签后面的冒号',
         labelCol: '标签的宽度',
+        minWidth: '最小宽度',
+        maxWidth: '最大宽度',
         hideRequiredMark: '隐藏必填字段的标签旁边的红色星号',
         formItemMarginBottom: '表单项的下边距',
         scrollToFirstError: '提交失败自动滚动到第一个错误字段',

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1540,7 +1540,9 @@ export default defineComponent({
                 const rule = data.activeRule;
                 let formData = {
                     formCreateChild: '' + rule.children[0],
-                    'formCreateWrap>labelWidth': ''
+                    'formCreateWrap>labelWidth': '',
+                    'formCreateStyle>minWidth': '',
+                    'formCreateStyle>maxWidth': ''
                 };
                 const appendConfigData = configRef.value.appendConfigData;
                 if (is.Function(appendConfigData)) {

--- a/packages/element-ui/src/config/base/field.js
+++ b/packages/element-ui/src/config/base/field.js
@@ -22,6 +22,16 @@ export default function field({t}) {
             value: '',
             title: t('form.labelWidth'),
         }, {
+            type: 'SizeInput',
+            field: 'formCreateStyle>minWidth',
+            value: '',
+            title: t('form.minWidth'),
+        }, {
+            type: 'SizeInput',
+            field: 'formCreateStyle>maxWidth',
+            value: '',
+            title: t('form.maxWidth'),
+        }, {
             type: 'Struct',
             field: '_control',
             name: 'control',

--- a/packages/element-ui/src/locale/en.js
+++ b/packages/element-ui/src/locale/en.js
@@ -11,6 +11,8 @@ const En = {
         size: 'Form size',
         event: 'Form event',
         labelWidth: 'Label width',
+        minWidth: 'Min width',
+        maxWidth: 'Max width',
         hideRequiredAsterisk: 'Hide the red asterisk next to the label of a required field',
         showMessage: 'Display verification error message',
         inlineMessage: 'Display validation information inline',

--- a/packages/element-ui/src/locale/zh-cn.js
+++ b/packages/element-ui/src/locale/zh-cn.js
@@ -11,6 +11,8 @@ const ZhCn = {
         size: '表单的尺寸',
         event: '表单事件',
         labelWidth: '标签的宽度',
+        minWidth: '最小宽度',
+        maxWidth: '最大宽度',
         hideRequiredAsterisk: '隐藏必填字段的标签旁边的红色星号',
         showMessage: '显示校验错误信息',
         inlineMessage: '以行内形式展示校验信息',

--- a/packages/vant/src/components/FcDesigner.vue
+++ b/packages/vant/src/components/FcDesigner.vue
@@ -1538,7 +1538,9 @@ export default defineComponent({
                 const rule = data.activeRule;
                 let formData = {
                     formCreateChild: '' + rule.children[0],
-                    'formCreateWrap>labelWidth': ''
+                    'formCreateWrap>labelWidth': '',
+                    'formCreateStyle>minWidth': '',
+                    'formCreateStyle>maxWidth': ''
                 };
                 const appendConfigData = configRef.value.appendConfigData;
                 if (is.Function(appendConfigData)) {

--- a/packages/vant/src/config/base/field.js
+++ b/packages/vant/src/config/base/field.js
@@ -70,6 +70,20 @@ export default function field({t}) {
             slot: 'append',
             value: '',
         }, {
+            type: 'SizeInput',
+            field: 'formCreateStyle>minWidth',
+            title: t('form.minWidth'),
+            col: {show: false},
+            slot: 'append',
+            value: '',
+        }, {
+            type: 'SizeInput',
+            field: 'formCreateStyle>maxWidth',
+            title: t('form.maxWidth'),
+            col: {show: false},
+            slot: 'append',
+            value: '',
+        }, {
             type: 'Struct',
             field: '_control',
             name: 'control',

--- a/packages/vant/src/locale/en.js
+++ b/packages/vant/src/locale/en.js
@@ -12,6 +12,8 @@ const En = {
         size: 'Form size',
         event: 'Form event',
         labelWidth: 'Label width',
+        minWidth: 'Min width',
+        maxWidth: 'Max width',
         hideRequiredAsterisk: 'Hide the red asterisk next to the label of a required field',
         showMessage: 'Display verification error message',
         inlineMessage: 'Display validation information inline',

--- a/packages/vant/src/locale/zh-cn.js
+++ b/packages/vant/src/locale/zh-cn.js
@@ -12,6 +12,8 @@ const ZhCn = {
         size: '表单的尺寸',
         event: '表单事件',
         labelWidth: '标签的宽度',
+        minWidth: '最小宽度',
+        maxWidth: '最大宽度',
         hideRequiredAsterisk: '隐藏必填字段的标签旁边的红色星号',
         showMessage: '显示校验错误信息',
         inlineMessage: '以行内形式展示校验信息',


### PR DESCRIPTION
## Summary
- support min/max width in base field config
- update designer to initialize new config fields
- add English and Chinese locale entries for min/max width

## Testing
- `npm run build:locale` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_b_683acc3c610c83268cce55e40fbe483c