### PR TITLE
Enable table form scrolling

### DIFF
--- a/packages/ant-design-vue/src/components/tableForm/TableForm.vue
+++ b/packages/ant-design-vue/src/components/tableForm/TableForm.vue
@@ -344,10 +344,11 @@ export default {
 }
 
 ._fc-tf-table {
-    width: 100%;
+    width: max-content;
+    min-width: 100%;
     height: 100%;
     overflow: hidden;
-    table-layout: fixed;
+    table-layout: auto;
     border: 1px solid #EBEEF5;
     border-bottom: 0 none;
 }

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -376,10 +376,11 @@ export default {
 }
 
 ._fc-tf-table {
-  width: 100%;
+  width: max-content;
+  min-width: 100%;
   height: 100%;
   overflow: hidden;
-  table-layout: fixed;
+  table-layout: auto;
   border: 1px solid #EBEEF5;
   border-bottom: 0 none;
 }

--- a/packages/vant/src/components/tableForm/TableForm.vue
+++ b/packages/vant/src/components/tableForm/TableForm.vue
@@ -352,10 +352,11 @@ export default {
 }
 
 ._fc-tf-table {
-    width: 100%;
+    width: max-content;
+    min-width: 100%;
     height: 100%;
     overflow: hidden;
-    table-layout: fixed;
+    table-layout: auto;
     border: 1px solid #EBEEF5;
     border-bottom: 0 none;
 }


### PR DESCRIPTION
## Summary
- adjust table form styles so columns can exceed container width

## Testing
- `npx eslint packages/ant-design-vue/src/components/tableForm/TableForm.vue packages/element-ui/src/components/tableForm/TableForm.vue packages/vant/src/components/tableForm/TableForm.vue` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_683acffa1c808326911de2c8161a1c44