### PR TITLE
Fix read-only table form

### DIFF
--- a/packages/ant-design-vue/src/components/tableForm/TableForm.vue
+++ b/packages/ant-design-vue/src/components/tableForm/TableForm.vue
@@ -13,7 +13,7 @@
             <i class="fc-icon icon-save" style="font-weight: 700;"></i>
             {{formCreateInject.t('batchExport') || '批量导出'}}
         </a-button>
-        <a-button type="link" class="fc-clock" v-if="!max || max > this.trs.length"
+        <a-button type="link" class="fc-clock" v-if="(!max || max > this.trs.length) && !disabled"
                   @click="addRaw(true)" :disabled="disabled"><i class="fc-icon icon-add-circle"
                                                                 style="font-weight: 700;"></i>
             {{formCreateInject.t('add') || '添加'}}

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -13,7 +13,7 @@
             <i class="fc-icon icon-save" style="font-weight: 700;"></i>
             {{ formCreateInject.t('batchExport') || '批量导出' }}
         </el-button>
-        <el-button link type="primary" class="fc-clock" v-if="!max || max > this.trs.length"
+        <el-button link type="primary" class="fc-clock" v-if="(!max || max > this.trs.length) && !disabled"
                    @click="addRaw(true)"><i class="fc-icon icon-add-circle" style="font-weight: 700;"></i>
             {{ formCreateInject.t('add') || '添加' }}
         </el-button>

--- a/packages/vant/src/components/tableForm/TableForm.vue
+++ b/packages/vant/src/components/tableForm/TableForm.vue
@@ -13,7 +13,7 @@
             <i class="fc-icon icon-save" style="font-weight: 700;"></i>
             {{ formCreateInject.t('batchExport') || '批量导出' }}
         </van-button>
-        <van-button type="primary" size="mini" class="fc-clock" v-if="!max || max > this.trs.length"
+        <van-button type="primary" size="mini" class="fc-clock" v-if="(!max || max > this.trs.length) && !disabled"
                     @click="addRaw(true)"><i class="fc-icon icon-add-circle" style="font-weight: 700;"></i>
             {{ formCreateInject.t('add') || '添加' }}
         </van-button>


### PR DESCRIPTION
## Summary
- hide table form add button when disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683ad6ed028483269922452fcf81b334