### PR TITLE
Add hidden condition struct

### DIFF
--- a/packages/ant-design-vue/src/components/FcDesigner.vue
+++ b/packages/ant-design-vue/src/components/FcDesigner.vue
@@ -1628,6 +1628,7 @@ export default defineComponent({
                         title: rule.title || '',
                         info: rule.info,
                         _control: rule._control,
+                        '_computed>hidden': rule._computed?.hidden,
                         ...formData
                     };
                     data.validateForm.value = {

--- a/packages/ant-design-vue/src/config/base/field.js
+++ b/packages/ant-design-vue/src/config/base/field.js
@@ -68,6 +68,18 @@ export default function field({t}) {
                     });
                 }
             }
+        }, {
+            type: 'Struct',
+            field: '_computed>hidden',
+            name: 'hidden',
+            value: {},
+            title: t('form.hiddenCondition'),
+            props: {
+                defaultValue: {},
+                validate(val) {
+                    return val && typeof val === 'object';
+                }
+            }
         },
     ];
 }

--- a/packages/ant-design-vue/src/locale/en.js
+++ b/packages/ant-design-vue/src/locale/en.js
@@ -5,6 +5,7 @@ const En = {
         title: 'Title',
         info: 'Info',
         control: 'Control',
+        hiddenCondition: 'Hidden condition',
         labelShow: 'Whether to display',
         labelStyle: 'Label style',
         formItem: 'Configure form item',

--- a/packages/ant-design-vue/src/locale/zh-cn.js
+++ b/packages/ant-design-vue/src/locale/zh-cn.js
@@ -5,6 +5,7 @@ const ZhCn = {
         title: '字段名称',
         info: '提示信息',
         control: '联动数据',
+        hiddenCondition: '隐藏条件',
         labelShow: '是否显示',
         labelStyle: '标签的样式',
         formItem: '配置表单项',

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1603,6 +1603,7 @@ export default defineComponent({
                         title: rule.title || '',
                         info: rule.info,
                         _control: rule._control,
+                        '_computed>hidden': rule._computed?.hidden,
                         ...formData
                     };
                     data.validateForm.value = {

--- a/packages/element-ui/src/config/base/field.js
+++ b/packages/element-ui/src/config/base/field.js
@@ -63,6 +63,18 @@ export default function field({t}) {
                     });
                 }
             }
+        }, {
+            type: 'Struct',
+            field: '_computed>hidden',
+            name: 'hidden',
+            value: {},
+            title: t('form.hiddenCondition'),
+            props: {
+                defaultValue: {},
+                validate(val) {
+                    return val && typeof val === 'object';
+                }
+            }
         },
     ];
 }

--- a/packages/element-ui/src/locale/en.js
+++ b/packages/element-ui/src/locale/en.js
@@ -5,6 +5,7 @@ const En = {
         title: 'Title',
         info: 'Info',
         control: 'Control',
+        hiddenCondition: 'Hidden condition',
         labelPosition: 'Label position',
         labelStyle: 'Label style',
         labelSuffix: 'Label suffix',

--- a/packages/element-ui/src/locale/zh-cn.js
+++ b/packages/element-ui/src/locale/zh-cn.js
@@ -5,6 +5,7 @@ const ZhCn = {
         title: '字段名称',
         info: '提示信息',
         control: '联动数据',
+        hiddenCondition: '隐藏条件',
         labelPosition: '标签的位置',
         labelStyle: '标签的样式',
         labelSuffix: '标签的后缀',

--- a/packages/vant/src/components/FcDesigner.vue
+++ b/packages/vant/src/components/FcDesigner.vue
@@ -1601,6 +1601,7 @@ export default defineComponent({
                         title: rule.title || '',
                         info: rule.info,
                         _control: rule._control,
+                        '_computed>hidden': rule._computed?.hidden,
                         ...formData
                     };
                     data.validateForm.value = {

--- a/packages/vant/src/config/base/field.js
+++ b/packages/vant/src/config/base/field.js
@@ -115,6 +115,18 @@ export default function field({t}) {
                     });
                 }
             }
+        }, {
+            type: 'Struct',
+            field: '_computed>hidden',
+            name: 'hidden',
+            value: {},
+            title: t('form.hiddenCondition'),
+            props: {
+                defaultValue: {},
+                validate(val) {
+                    return val && typeof val === 'object';
+                }
+            }
         },
     ];
 }

--- a/packages/vant/src/locale/en.js
+++ b/packages/vant/src/locale/en.js
@@ -5,6 +5,7 @@ const En = {
         title: 'Title',
         info: 'Info',
         control: 'Control',
+        hiddenCondition: 'Hidden condition',
         labelAlign: 'Label position',
         inputAlign: 'Input position',
         labelStyle: 'Label style',

--- a/packages/vant/src/locale/zh-cn.js
+++ b/packages/vant/src/locale/zh-cn.js
@@ -5,6 +5,7 @@ const ZhCn = {
         title: '字段名称',
         info: '提示信息',
         control: '联动数据',
+        hiddenCondition: '隐藏条件',
         labelAlign: '标签的位置',
         inputAlign: '内容的位置',
         labelStyle: '标签的样式',


### PR DESCRIPTION
## Summary
- support editing hidden conditions in base field config
- show `_computed.hidden` in rule editor base form
- localize hidden condition label for all UI frameworks

## Testing
- `npm run build:locale` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b34afbe7c832693fdf936b136bff9