### PR TITLE
Add protocol input type

### DIFF
--- a/packages/ant-design-vue/src/config/index.js
+++ b/packages/ant-design-vue/src/config/index.js
@@ -3,6 +3,7 @@ import checkbox from './rule/checkbox';
 import input from './rule/input';
 import textarea from './rule/textarea';
 import password from './rule/password';
+import protocol from './rule/protocol';
 import number from './rule/number';
 import select from './rule/select';
 import _switch from './rule/switch';
@@ -41,7 +42,7 @@ import image from './rule/image';
 
 
 const ruleList = [
-    input, textarea, password, number, radio, checkbox, select, _switch, rate, time, timeRange, slider, date, dateRange, cascader, upload, transfer, tree, treeSelect, editor,
+    input, textarea, password, protocol, number, radio, checkbox, select, _switch, rate, time, timeRange, slider, date, dateRange, cascader, upload, transfer, tree, treeSelect, editor,
     group, subForm, tableForm, tableFormColumn,
     alert, button, text, html, divider, tag, image,
     row, table, tabs, space, card, collapse,

--- a/packages/ant-design-vue/src/config/rule/input.js
+++ b/packages/ant-design-vue/src/config/rule/input.js
@@ -22,6 +22,16 @@ export default {
             props: {}
         };
     },
+    watch: {
+        value({value, rule}) {
+            rule._link = /^https?:/.test(value) ? value : '';
+        }
+    },
+    attrs: {
+        link({rule}) {
+            return rule._link || '';
+        }
+    },
     props(_, {t}) {
         return localeProps(t, name + '.props', [
             {
@@ -38,6 +48,7 @@ export default {
                     {label: 'date', value: 'date'},
                     {label: 'month', value: 'month'},
                     {label: 'datetime-local', value: 'datetime-local'},
+                    {label: 'protocol', value: 'protocol'},
                 ])
             },
             {

--- a/packages/ant-design-vue/src/config/rule/protocol.js
+++ b/packages/ant-design-vue/src/config/rule/protocol.js
@@ -1,0 +1,39 @@
+import uniqueId from '@form-create/utils/lib/unique';
+import {localeProps} from '../../utils';
+
+const label = '协议';
+const name = 'protocol';
+
+export default {
+    menu: 'main',
+    icon: 'icon-link',
+    label,
+    name,
+    input: true,
+    event: ['blur', 'focus', 'change', 'pressEnter'],
+    rule({t}) {
+        return {
+            type: 'input',
+            field: uniqueId(),
+            title: t('com.protocol.name'),
+            info: '',
+            $required: false,
+            props: {type: 'text'}
+        };
+    },
+    watch: {
+        value({value, rule}) {
+            rule._link = /^https?:/.test(value) ? value : '';
+        }
+    },
+    attrs: {
+        link({rule}) {
+            return rule._link || '';
+        }
+    },
+    props(_, {t}) {
+        return localeProps(t, name + '.props', [
+            { type: 'input', field: 'placeholder' },
+        ]);
+    }
+};

--- a/packages/ant-design-vue/src/locale/en.js
+++ b/packages/ant-design-vue/src/locale/en.js
@@ -345,6 +345,7 @@ const En = {
         quarter: 'quarter',
         datetime: 'datetime',
         'datetime-local': 'datetime',
+        protocol: 'protocol',
         datetimerange: 'datetimerange',
         daterange: 'daterange',
         monthrange: 'monthrange',
@@ -662,6 +663,9 @@ const En = {
                 allowClear: 'Whether to display the clear button',
                 bordered: 'Whether there is a border',
             }
+        },
+        protocol: {
+            name: 'Protocol',
         },
         radio: {
             name: 'Radio',

--- a/packages/ant-design-vue/src/locale/zh-cn.js
+++ b/packages/ant-design-vue/src/locale/zh-cn.js
@@ -345,6 +345,7 @@ const ZhCn = {
         quarter: '季度',
         datetime: '日期时间',
         'datetime-local': '日期时间',
+        protocol: '协议',
         datetimerange: '日期时间区间',
         daterange: '日期区间',
         monthrange: '月份区间',
@@ -662,6 +663,9 @@ const ZhCn = {
                 allowClear: '是否显示清除按钮',
                 bordered: '是否有边框',
             }
+        },
+        protocol: {
+            name: '协议输入框',
         },
         radio: {
             name: '单选框',

--- a/packages/element-ui/src/config/index.js
+++ b/packages/element-ui/src/config/index.js
@@ -3,6 +3,7 @@ import checkbox from './rule/checkbox';
 import input from './rule/input';
 import textarea from './rule/textarea';
 import password from './rule/password';
+import protocol from './rule/protocol';
 import number from './rule/number';
 import select from './rule/select';
 import _switch from './rule/switch';
@@ -42,7 +43,7 @@ import image from './rule/image';
 
 
 const ruleList = [
-    input, textarea, password, number, radio, checkbox, select, _switch, rate, time, timeRange, slider, date, dateRange, color, cascader, upload, transfer, tree, treeSelect, editor,
+    input, textarea, password, protocol, number, radio, checkbox, select, _switch, rate, time, timeRange, slider, date, dateRange, color, cascader, upload, transfer, tree, treeSelect, editor,
     group, subForm, tableForm, tableFormColumn,
     alert, button, text, html, divider, tag, image,
     row, table, tabs, space, card, collapse,

--- a/packages/element-ui/src/config/rule/input.js
+++ b/packages/element-ui/src/config/rule/input.js
@@ -22,6 +22,16 @@ export default {
             props: {}
         };
     },
+    watch: {
+        value({value, rule}) {
+            rule._link = /^https?:/.test(value) ? value : '';
+        }
+    },
+    attrs: {
+        link({rule}) {
+            return rule._link || '';
+        }
+    },
     props(_, {t}) {
         return localeProps(t, name + '.props', [
             {
@@ -42,6 +52,7 @@ export default {
                     {label: 'date', value: 'date'},
                     {label: 'month', value: 'month'},
                     {label: 'datetime-local', value: 'datetime-local'},
+                    {label: 'protocol', value: 'protocol'},
                 ])
             },
             {

--- a/packages/element-ui/src/config/rule/protocol.js
+++ b/packages/element-ui/src/config/rule/protocol.js
@@ -1,0 +1,39 @@
+import uniqueId from '@form-create/utils/lib/unique';
+import {localeProps} from '../../utils';
+
+const label = '协议';
+const name = 'protocol';
+
+export default {
+    menu: 'main',
+    icon: 'icon-link',
+    label,
+    name,
+    input: true,
+    event: ['blur', 'focus', 'change', 'input', 'clear'],
+    rule({t}) {
+        return {
+            type: 'input',
+            field: uniqueId(),
+            title: t('com.protocol.name'),
+            info: '',
+            $required: false,
+            props: {type: 'text'}
+        };
+    },
+    watch: {
+        value({value, rule}) {
+            rule._link = /^https?:/.test(value) ? value : '';
+        }
+    },
+    attrs: {
+        link({rule}) {
+            return rule._link || '';
+        }
+    },
+    props(_, {t}) {
+        return localeProps(t, name + '.props', [
+            { type: 'input', field: 'placeholder' },
+        ]);
+    }
+};

--- a/packages/element-ui/src/locale/en.js
+++ b/packages/element-ui/src/locale/en.js
@@ -319,6 +319,7 @@ const En = {
         week: 'week',
         datetime: 'datetime',
         'datetime-local': 'datetime',
+        protocol: 'protocol',
         datetimerange: 'datetimerange',
         daterange: 'daterange',
         monthrange: 'monthrange',
@@ -674,6 +675,9 @@ const En = {
                 placeholder: 'Placeholder',
                 clearable: 'Whether to display the clear button'
             }
+        },
+        protocol: {
+            name: 'Protocol',
         },
         radio: {
             name: 'Radio',

--- a/packages/element-ui/src/locale/zh-cn.js
+++ b/packages/element-ui/src/locale/zh-cn.js
@@ -319,6 +319,7 @@ const ZhCn = {
         week: '一周',
         datetime: '日期时间',
         'datetime-local': '日期时间',
+        protocol: '协议',
         datetimerange: '日期时间区间',
         daterange: '日期区间',
         monthrange: '月份区间',
@@ -674,6 +675,9 @@ const ZhCn = {
                 placeholder: '输入框占位文本',
                 clearable: '是否显示清除按钮'
             }
+        },
+        protocol: {
+            name: '协议输入框',
         },
         radio: {
             name: '单选框',

--- a/packages/vant/src/config/index.js
+++ b/packages/vant/src/config/index.js
@@ -1,6 +1,7 @@
 import input from './rule/input';
 import textarea from './rule/textarea';
 import password from './rule/password';
+import protocol from './rule/protocol';
 import stepper from './rule/stepper';
 import checkbox from './rule/checkbox';
 import radio from './rule/radio';
@@ -39,7 +40,7 @@ import image from './rule/image';
 
 
 const ruleList = [
-    input, textarea, password, stepper, radio, checkbox, select, _switch, rate, time, date, cascader, calendar, calendarRange, slider, uploader,
+    input, textarea, password, protocol, stepper, radio, checkbox, select, _switch, rate, time, date, cascader, calendar, calendarRange, slider, uploader,
     group, subForm, tableForm, tableFormColumn,
     noticeBar, button, text, html, divider, tag, image, icon,
     row, col, table,

--- a/packages/vant/src/config/rule/input.js
+++ b/packages/vant/src/config/rule/input.js
@@ -22,6 +22,16 @@ export default {
             props: {}
         };
     },
+    watch: {
+        value({value, rule}) {
+            rule._link = /^https?:/.test(value) ? value : '';
+        }
+    },
+    attrs: {
+        link({rule}) {
+            return rule._link || '';
+        }
+    },
     props(_, {t}) {
         return localeProps(t, name + '.props', [
             {
@@ -38,6 +48,7 @@ export default {
                     {label: 'date', value: 'date'},
                     {label: 'month', value: 'month'},
                     {label: 'datetime-local', value: 'datetime-local'},
+                    {label: 'protocol', value: 'protocol'},
                 ])
             },
             {

--- a/packages/vant/src/config/rule/protocol.js
+++ b/packages/vant/src/config/rule/protocol.js
@@ -1,0 +1,39 @@
+import uniqueId from '@form-create/utils/lib/unique';
+import {localeProps} from '../../utils';
+
+const label = '协议';
+const name = 'protocol';
+
+export default {
+    menu: 'main',
+    icon: 'icon-link',
+    label,
+    name,
+    input: true,
+    event: ['blur', 'focus', 'clear', 'click'],
+    rule({t}) {
+        return {
+            type: 'input',
+            field: uniqueId(),
+            title: t('com.protocol.name'),
+            info: '',
+            $required: false,
+            props: {type: 'text'}
+        };
+    },
+    watch: {
+        value({value, rule}) {
+            rule._link = /^https?:/.test(value) ? value : '';
+        }
+    },
+    attrs: {
+        link({rule}) {
+            return rule._link || '';
+        }
+    },
+    props(_, {t}) {
+        return localeProps(t, name + '.props', [
+            { type: 'input', field: 'placeholder' },
+        ]);
+    }
+};

--- a/packages/vant/src/locale/en.js
+++ b/packages/vant/src/locale/en.js
@@ -329,6 +329,7 @@ const En = {
         week: 'week',
         datetime: 'datetime',
         'datetime-local': 'datetime',
+        protocol: 'protocol',
         datetimerange: 'datetimerange',
         daterange: 'daterange',
         monthrange: 'monthrange',
@@ -624,6 +625,9 @@ const En = {
         },
         password: {
             name: 'Password',
+        },
+        protocol: {
+            name: 'Protocol',
         },
         radio: {
             name: 'Radio',

--- a/packages/vant/src/locale/zh-cn.js
+++ b/packages/vant/src/locale/zh-cn.js
@@ -329,6 +329,7 @@ const ZhCn = {
         week: '一周',
         datetime: '日期时间',
         'datetime-local': '日期时间',
+        protocol: '协议',
         datetimerange: '日期时间区间',
         daterange: '日期区间',
         monthrange: '月份区间',
@@ -623,6 +624,9 @@ const ZhCn = {
         },
         password: {
             name: '密码输入框',
+        },
+        protocol: {
+            name: '协议输入框',
         },
         radio: {
             name: '单选框',


### PR DESCRIPTION
## Summary
- add link detection watchers for input components when using `protocol` type

## Testing
- `npm run build:locale` *(fails: lerna not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ad5cde7008320ba95e61de787ec69