### PR TITLE
feat: add collaborative editing hooks

### DIFF
--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -4,19 +4,20 @@ import draggable from 'vuedraggable/src/vuedraggable';
 
 export default defineComponent({
     name: 'DragBox',
+    inject: ['collabState'],
     props: ['rule', 'tag', 'formCreateInject', 'list'],
-    render(ctx) {
-        const attrs = {...ctx.$props.rule.props, ...ctx.$attrs};
-        let _class = '_fd-' + ctx.$props.tag + '-drag _fd-drag-box';
-        if (!Object.keys(ctx.$slots).length) {
+    render() {
+        const attrs = {...this.rule.props, ...this.$attrs};
+        let _class = '_fd-' + this.tag + '-drag _fd-drag-box';
+        if (!Object.keys(this.$slots).length) {
             _class += ' drag-holder';
         }
         attrs.class = _class;
-        attrs.modelValue = ctx.$props.list || [...ctx.$props.formCreateInject.children];
+        attrs.modelValue = this.list || [...this.formCreateInject.children];
 
         const keys = {};
-        if (ctx.$slots.default) {
-            const children = ctx.$slots.default();
+        if (this.$slots.default) {
+            const children = this.$slots.default();
             children.forEach(v => {
                 if (v.key) {
                     keys[v.key] = v;
@@ -26,24 +27,43 @@ export default defineComponent({
         return h(draggable, attrs, {
             item: ({element, index}) => {
                 const key = element?.__fc__?.key;
+                let vnode;
                 if (key) {
-                    let vnode = keys['_' + element.slot];
+                    vnode = keys['_' + element.slot];
                     if (vnode) {
                         vnode.children.forEach(v => {
                             if (v.key === key + 'fc') {
-                                vnode = v
+                                vnode = v;
                             }
                         });
                     } else {
                         vnode = keys[key + 'fc'];
                     }
-                    if (vnode) {
-                        return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key}, vnode);
-                    }
                 }
-                return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key: index}, null);
+                const nodes = [];
+                if (vnode) {
+                    nodes.push(vnode);
+                }
+                const field = element && element.field;
+                const user = field && this.collabState && this.collabState[field];
+                if (user) {
+                    nodes.push(h('span', {class: 'fc-collab-indicator'}, user));
+                }
+                return h('div', {class: '_fc-' + this.tag + '-item _fd-drag-item', key: key || index}, nodes);
             }
         });
     }
 });
 </script>
+<style>
+.fc-collab-indicator {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: rgba(255, 255, 0, 0.8);
+    font-size: 12px;
+    padding: 2px 4px;
+    z-index: 10;
+    border-radius: 2px;
+}
+</style>

--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -44,8 +44,9 @@ export default defineComponent({
                 if (vnode) {
                     nodes.push(vnode);
                 }
+                const fid = element && (element._fc_id || (element.__fc__ && element.__fc__.id));
                 const field = element && element.field;
-                const user = field && this.collabState && this.collabState[field];
+                const user = this.collabState && (this.collabState[fid] || this.collabState[field]);
                 if (user) {
                     nodes.push(h('span', {class: 'fc-collab-indicator'}, user));
                 }

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -497,7 +497,7 @@ export default defineComponent({
         // eslint-disable-next-line no-console
         console.log('[fc-designer emit]', name, payload);
         if (name === 'update-field') {
-          const key = payload && (payload.id || payload.field);
+          const key = payload && ((payload.id || payload.field) + (payload.row ? ':' + payload.row : ''));
           clearTimeout(timers[key]);
           timers[key] = setTimeout(() => {
             vm.emit(name, payload);
@@ -1830,13 +1830,15 @@ export default defineComponent({
           const oldOn = rule.on || {};
           const fieldConst = JSON.stringify(rule.field);
           const idConst = JSON.stringify(rule._fc_id || (rule.__fc__ && rule.__fc__.id));
+          const rowConst = JSON.stringify(rule._fc_table_row);
           const wrap = (eventName, handler, withVal) => {
             const valuePart = withVal ? ', value: arguments[0]' : '';
+            const rowPart = rowConst && rowConst !== 'undefined' ? `, row: ${rowConst}` : '';
             const handlerStr = typeof handler === 'function'
               ? `(${handler.toString()}).apply(this, arguments);`
               : '';
             const body =
-              `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', {id: ${idConst}, field: ${fieldConst}${valuePart}});` +
+              `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', {id: ${idConst}, field: ${fieldConst}${rowPart}${valuePart}});` +
               (handlerStr ? `\n${handlerStr}` : '');
             return new Function(body);
           };

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1813,20 +1813,22 @@ export default defineComponent({
         }
         if (config.input) {
           const oldOn = rule.on || {};
+          const fieldConst = JSON.stringify(rule.field);
+          const wrap = (eventName, handler, withVal) => {
+            const valuePart = withVal ? ', value: arguments[0]' : '';
+            const handlerStr = typeof handler === 'function'
+              ? `(${handler.toString()}).apply(this, arguments);`
+              : '';
+            const body =
+              `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', {field: ${fieldConst}${valuePart}});` +
+              (handlerStr ? `\n${handlerStr}` : '');
+            return new Function(body);
+          };
           rule.on = {
             ...oldOn,
-            focus: (...args) => {
-              window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('focus-field', {field: rule.field});
-              oldOn.focus && oldOn.focus(...args);
-            },
-            blur: (...args) => {
-              window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('blur-field', {field: rule.field});
-              oldOn.blur && oldOn.blur(...args);
-            },
-            input: (val, ...args) => {
-              window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('update-field', {field: rule.field, value: val});
-              oldOn.input && oldOn.input(val, ...args);
-            }
+            focus: wrap('focus-field', oldOn.focus),
+            blur: wrap('blur-field', oldOn.blur),
+            input: wrap('update-field', oldOn.input, true)
           };
         }
         if (config.languageKey) {

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1829,7 +1829,10 @@ export default defineComponent({
         if (config.input) {
           const oldOn = rule.on || {};
           const fieldConst = JSON.stringify(rule.field);
-          const idConst = JSON.stringify(rule._fc_id || (rule.__fc__ && rule.__fc__.id));
+          // prefer designer-assigned id, fall back to built-in id or field
+          const idConst = JSON.stringify(
+            rule._fc_id || rule.id || (rule.__fc__ && rule.__fc__.id) || rule.field
+          );
           const rowConst = JSON.stringify(rule._fc_table_row);
           const wrap = (eventName, handler, withVal) => {
             const valuePart = withVal ? ', value: arguments[0]' : '';

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -479,15 +479,27 @@ export default defineComponent({
       default: undefined,
     },
     locale: Object,
-    handle: Array
+    handle: Array,
+    // current editing users { [fieldId]: userName }
+    editing: {
+      type: Object,
+      default: () => ({})
+    }
   },
-  emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice'],
+  emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice', 'focus-field', 'blur-field', 'update-field'],
   setup(props) {
-    const {menu, height, mask, locale, handle} = toRefs(props);
+    const {menu, height, mask, locale, handle, editing} = toRefs(props);
     const vm = getCurrentInstance();
     const fcx = reactive({active: null});
     provide('fcx', fcx);
     provide('designer', vm);
+    // collaborative editing state
+    const collabState = reactive(editing.value || {});
+    watch(editing, (val) => {
+      Object.keys(collabState).forEach(k => delete collabState[k]);
+      Object.assign(collabState, val || {});
+    });
+    provide('collabState', collabState);
 
     const configRef = toRef(props, 'config', {});
     const baseRule = toRef(configRef.value, 'baseRule', null);
@@ -1793,6 +1805,24 @@ export default defineComponent({
         }
         if (config.input && !rule.field) {
           rule.field = uniqueId();
+        }
+        if (config.input) {
+          const oldOn = rule.on || {};
+          rule.on = {
+            ...oldOn,
+            focus: (...args) => {
+              vm.emit('focus-field', {field: rule.field});
+              oldOn.focus && oldOn.focus(...args);
+            },
+            blur: (...args) => {
+              vm.emit('blur-field', {field: rule.field});
+              oldOn.blur && oldOn.blur(...args);
+            },
+            input: (val, ...args) => {
+              vm.emit('update-field', {field: rule.field, value: val});
+              oldOn.input && oldOn.input(val, ...args);
+            }
+          };
         }
         if (config.languageKey) {
           methods.mergeOptions({

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -492,6 +492,9 @@ export default defineComponent({
     const vm = getCurrentInstance();
     if (typeof window !== 'undefined') {
       window.__FC_DESIGNER_EMIT__ = (name, payload) => {
+        // debug output for collaborative events
+        // eslint-disable-next-line no-console
+        console.log('[fc-designer emit]', name, payload);
         vm.emit(name, payload);
       };
     }
@@ -503,6 +506,8 @@ export default defineComponent({
     watch(editing, (val) => {
       Object.keys(collabState).forEach(k => delete collabState[k]);
       Object.assign(collabState, val || {});
+      // eslint-disable-next-line no-console
+      console.log('[fc-designer editing]', collabState);
     });
     provide('collabState', collabState);
 

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -490,6 +490,11 @@ export default defineComponent({
   setup(props) {
     const {menu, height, mask, locale, handle, editing} = toRefs(props);
     const vm = getCurrentInstance();
+    if (typeof window !== 'undefined') {
+      window.__FC_DESIGNER_EMIT__ = (name, payload) => {
+        vm.emit(name, payload);
+      };
+    }
     const fcx = reactive({active: null});
     provide('fcx', fcx);
     provide('designer', vm);
@@ -1811,15 +1816,15 @@ export default defineComponent({
           rule.on = {
             ...oldOn,
             focus: (...args) => {
-              vm.emit('focus-field', {field: rule.field});
+              window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('focus-field', {field: rule.field});
               oldOn.focus && oldOn.focus(...args);
             },
             blur: (...args) => {
-              vm.emit('blur-field', {field: rule.field});
+              window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('blur-field', {field: rule.field});
               oldOn.blur && oldOn.blur(...args);
             },
             input: (val, ...args) => {
-              vm.emit('update-field', {field: rule.field, value: val});
+              window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('update-field', {field: rule.field, value: val});
               oldOn.input && oldOn.input(val, ...args);
             }
           };

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -480,7 +480,7 @@ export default defineComponent({
     },
     locale: Object,
     handle: Array,
-    // current editing users { [fieldId]: userName }
+    // current editing users { [id or field]: userName }
     editing: {
       type: Object,
       default: () => ({})
@@ -491,11 +491,21 @@ export default defineComponent({
     const {menu, height, mask, locale, handle, editing} = toRefs(props);
     const vm = getCurrentInstance();
     if (typeof window !== 'undefined') {
+      const timers = {};
       window.__FC_DESIGNER_EMIT__ = (name, payload) => {
         // debug output for collaborative events
         // eslint-disable-next-line no-console
         console.log('[fc-designer emit]', name, payload);
-        vm.emit(name, payload);
+        if (name === 'update-field') {
+          const key = payload && (payload.id || payload.field);
+          clearTimeout(timers[key]);
+          timers[key] = setTimeout(() => {
+            vm.emit(name, payload);
+            delete timers[key];
+          }, 300);
+        } else {
+          vm.emit(name, payload);
+        }
       };
     }
     const fcx = reactive({active: null});
@@ -1819,13 +1829,14 @@ export default defineComponent({
         if (config.input) {
           const oldOn = rule.on || {};
           const fieldConst = JSON.stringify(rule.field);
+          const idConst = JSON.stringify(rule._fc_id || (rule.__fc__ && rule.__fc__.id));
           const wrap = (eventName, handler, withVal) => {
             const valuePart = withVal ? ', value: arguments[0]' : '';
             const handlerStr = typeof handler === 'function'
               ? `(${handler.toString()}).apply(this, arguments);`
               : '';
             const body =
-              `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', {field: ${fieldConst}${valuePart}});` +
+              `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', {id: ${idConst}, field: ${fieldConst}${valuePart}});` +
               (handlerStr ? `\n${handlerStr}` : '');
             return new Function(body);
           };

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -43,6 +43,7 @@
 import {markRaw, reactive} from 'vue';
 import ImportSteps from '../import/ImportSteps.vue';
 import * as XLSX from 'xlsx';
+import uniqueId from '@form-create/utils/lib/unique';
 
 export default {
     name: 'TableForm',
@@ -628,6 +629,16 @@ export default {
             const raw = this.trs[idx];
             this.fapi.setChildrenFormData(raw, formData, true);
         },
+        setFieldByRow(rowId, field, value) {
+            const idx = this.trs.findIndex(tr => tr._fc_row_id === rowId);
+            if (idx === -1) {
+                return;
+            }
+            const data = this.fapi.getChildrenFormData(this.trs[idx]);
+            data[field] = value;
+            this.setRawData(idx, data);
+            this.updateValue();
+        },
         updateTable() {
             try {
                 // 更新内部 modelValue 副本，处理不同类型的数据
@@ -712,6 +723,9 @@ export default {
                 return;
             }
             const tr = this.formCreateInject.form.parseJson(this.copyTrs)[0];
+            if (!tr._fc_row_id) {
+                tr._fc_row_id = uniqueId();
+            }
             if (this.trs.length === 1 && this.trs[0]._isEmpty) {
                 this.trs.splice(0, 1);
             }
@@ -724,6 +738,17 @@ export default {
         },
         updateRaw(tr) {
             const idx = this.trs.indexOf(tr);
+            const rowId = tr._fc_row_id || uniqueId();
+            tr._fc_row_id = rowId;
+            const markRow = (rules) => {
+                (rules || []).forEach(r => {
+                    r._fc_table_row = rowId;
+                    if (Array.isArray(r.children)) {
+                        markRow(r.children);
+                    }
+                });
+            };
+            markRow(tr.children);
             tr.children[0].props.innerText = idx + 1;
             tr.children[tr.children.length - 1].children[0].props.onClick = () => {
                 this.delRaw(idx);


### PR DESCRIPTION
## Summary
- expose `editing` prop and forward focus/blur/input events for collaborative edits
- inject collaborative state to show editing user badges on drag items

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c14577c9b883228d2a4fb44619ed9c