### PR TITLE
feat: add collaborative editing hooks

### DIFF
--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -44,7 +44,8 @@ export default defineComponent({
                 if (vnode) {
                     nodes.push(vnode);
                 }
-                const fid = element && (element._fc_id || (element.__fc__ && element.__fc__.id));
+                const row = element && element._fc_table_row;
+                const fid = row !== undefined ? row : (element && (element._fc_id || (element.__fc__ && element.__fc__.id)));
                 const field = element && element.field;
                 const user = this.collabState && (this.collabState[fid] || this.collabState[field]);
                 if (user) {

--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -4,19 +4,20 @@ import draggable from 'vuedraggable/src/vuedraggable';
 
 export default defineComponent({
     name: 'DragBox',
+    inject: ['collabState'],
     props: ['rule', 'tag', 'formCreateInject', 'list'],
-    render(ctx) {
-        const attrs = {...ctx.$props.rule.props, ...ctx.$attrs};
-        let _class = '_fd-' + ctx.$props.tag + '-drag _fd-drag-box';
-        if (!Object.keys(ctx.$slots).length) {
+    render() {
+        const attrs = {...this.rule.props, ...this.$attrs};
+        let _class = '_fd-' + this.tag + '-drag _fd-drag-box';
+        if (!Object.keys(this.$slots).length) {
             _class += ' drag-holder';
         }
         attrs.class = _class;
-        attrs.modelValue = ctx.$props.list || [...ctx.$props.formCreateInject.children];
+        attrs.modelValue = this.list || [...this.formCreateInject.children];
 
         const keys = {};
-        if (ctx.$slots.default) {
-            const children = ctx.$slots.default();
+        if (this.$slots.default) {
+            const children = this.$slots.default();
             children.forEach(v => {
                 if (v.key) {
                     keys[v.key] = v;
@@ -26,24 +27,44 @@ export default defineComponent({
         return h(draggable, attrs, {
             item: ({element, index}) => {
                 const key = element?.__fc__?.key;
+                let vnode;
                 if (key) {
-                    let vnode = keys['_' + element.slot];
+                    vnode = keys['_' + element.slot];
                     if (vnode) {
                         vnode.children.forEach(v => {
                             if (v.key === key + 'fc') {
-                                vnode = v
+                                vnode = v;
                             }
                         });
                     } else {
                         vnode = keys[key + 'fc'];
                     }
-                    if (vnode) {
-                        return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key}, vnode);
-                    }
                 }
-                return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key: index}, null);
+                const nodes = [];
+                if (vnode) {
+                    nodes.push(vnode);
+                }
+                const fid = element && (element._fc_id || (element.__fc__ && element.__fc__.id));
+                const field = element && element.field;
+                const user = this.collabState && (this.collabState[fid] || this.collabState[field]);
+                if (user) {
+                    nodes.push(h('span', {class: 'fc-collab-indicator'}, user));
+                }
+                return h('div', {class: '_fc-' + this.tag + '-item _fd-drag-item', key: key || index}, nodes);
             }
         });
     }
 });
 </script>
+<style>
+.fc-collab-indicator {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: rgba(255, 255, 0, 0.8);
+    font-size: 12px;
+    padding: 2px 4px;
+    z-index: 10;
+    border-radius: 2px;
+}
+</style>

--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -45,9 +45,12 @@ export default defineComponent({
                     nodes.push(vnode);
                 }
                 const row = element && element._fc_table_row;
-                const fid = row !== undefined ? row : (element && (element._fc_id || (element.__fc__ && element.__fc__.id)));
                 const field = element && element.field;
-                const user = this.collabState && (this.collabState[fid] || this.collabState[field]);
+                const fid =
+                    row !== undefined && field !== undefined
+                        ? row + ':' + field
+                        : (element && (element._fc_id || (element.__fc__ && element.__fc__.id)));
+                const user = this.collabState && this.collabState[fid];
                 if (user) {
                     nodes.push(h('span', {class: 'fc-collab-indicator'}, user));
                 }

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1732,7 +1732,7 @@ export default defineComponent({
       batchReplaceUni(json) {
         const regex = /"_fc_id"\s*:\s*"(\w[\w\d]+)"/g;
         json = json.replace(regex, () => {
-          return `"_fc_id":"id_${uniqueId()}"`;
+          return `"_fc_id":"${uniqueId()}"`;
         });
         return json;
       },
@@ -1842,8 +1842,8 @@ export default defineComponent({
               ? 'payload.value = arguments[0];'
               : '';
             const body =
-              `var payload = {id: ${idConst}, field: ${fieldConst}};\n` +
               `var row = this.rule && this.rule._fc_table_row;\n` +
+              `var payload = {id: row !== undefined ? row : ${idConst}, field: ${fieldConst}};\n` +
               `if (row !== undefined) payload.row = row;\n` +
               `${valueAssign}\n` +
               `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', payload);` +

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1809,7 +1809,7 @@ export default defineComponent({
         }
         rule._menu = markRaw(config);
         if (!rule._fc_id) {
-          rule._fc_id = 'id_' + uniqueId();
+          rule._fc_id = uniqueId();
         }
         if (!rule.name) {
           rule.name = 'ref_' + uniqueId();

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1832,6 +1832,9 @@ export default defineComponent({
         }
         if (config.input) {
           const oldOn = rule.on || {};
+          // stash original handlers so child components (e.g. TableForm)
+          // can wrap without re-emitting designer hooks
+          rule._fc_on = oldOn;
           const fieldConst = JSON.stringify(rule.field);
           // prefer designer-assigned id, fall back to built-in id or field
           const idConst = JSON.stringify(

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -1846,11 +1846,8 @@ export default defineComponent({
                 ? `(${handler.toString()}).apply(this, arguments);`
                 : '';
             const valueAssign = withVal ? 'payload.value = arguments[0];\n' : '';
-            const rowConst =
-              rule._fc_table_row !== undefined
-                ? JSON.stringify(rule._fc_table_row)
-                : null;
-            const idExpr = rowConst !== null ? rowConst : idConst;
+            const idExpr =
+              `(this && this.rule && this.rule._fc_table_row !== undefined ? this.rule._fc_table_row : ${idConst})`;
             const body =
               `var payload = {id: ${idExpr}, field: ${fieldConst}};\n` +
               valueAssign +

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -479,15 +479,47 @@ export default defineComponent({
       default: undefined,
     },
     locale: Object,
-    handle: Array
+    handle: Array,
+    // current editing users { [id or field]: userName }
+    editing: {
+      type: Object,
+      default: () => ({})
+    }
   },
-  emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice'],
+  emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice', 'focus-field', 'blur-field', 'update-field'],
   setup(props) {
-    const {menu, height, mask, locale, handle} = toRefs(props);
+    const {menu, height, mask, locale, handle, editing} = toRefs(props);
     const vm = getCurrentInstance();
+    if (typeof window !== 'undefined') {
+      const timers = {};
+      window.__FC_DESIGNER_EMIT__ = (name, payload) => {
+        // debug output for collaborative events
+        // eslint-disable-next-line no-console
+        console.log('[fc-designer emit]', name, payload);
+        if (name === 'update-field') {
+          const key = payload && ((payload.id || payload.field) + (payload.row ? ':' + payload.row : ''));
+          clearTimeout(timers[key]);
+          timers[key] = setTimeout(() => {
+            vm.emit(name, payload);
+            delete timers[key];
+          }, 300);
+        } else {
+          vm.emit(name, payload);
+        }
+      };
+    }
     const fcx = reactive({active: null});
     provide('fcx', fcx);
     provide('designer', vm);
+    // collaborative editing state
+    const collabState = reactive(editing.value || {});
+    watch(editing, (val) => {
+      Object.keys(collabState).forEach(k => delete collabState[k]);
+      Object.assign(collabState, val || {});
+      // eslint-disable-next-line no-console
+      console.log('[fc-designer editing]', collabState);
+    });
+    provide('collabState', collabState);
 
     const configRef = toRef(props, 'config', {});
     const baseRule = toRef(configRef.value, 'baseRule', null);
@@ -1793,6 +1825,37 @@ export default defineComponent({
         }
         if (config.input && !rule.field) {
           rule.field = uniqueId();
+        }
+        if (config.input) {
+          const oldOn = rule.on || {};
+          const fieldConst = JSON.stringify(rule.field);
+          // prefer designer-assigned id, fall back to built-in id or field
+          const idConst = JSON.stringify(
+            rule._fc_id || rule.id || (rule.__fc__ && rule.__fc__.id) || rule.field
+          );
+          const wrap = (eventName, handler, withVal) => {
+            const handlerStr =
+              typeof handler === 'function'
+                ? `(${handler.toString()}).apply(this, arguments);`
+                : '';
+            const valueAssign = withVal
+              ? 'payload.value = arguments[0];'
+              : '';
+            const body =
+              `var payload = {id: ${idConst}, field: ${fieldConst}};\n` +
+              `var row = this.rule && this.rule._fc_table_row;\n` +
+              `if (row !== undefined) payload.row = row;\n` +
+              `${valueAssign}\n` +
+              `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', payload);` +
+              (handlerStr ? `\n${handlerStr}` : '');
+            return new Function(body);
+          };
+          rule.on = {
+            ...oldOn,
+            focus: wrap('focus-field', oldOn.focus),
+            blur: wrap('blur-field', oldOn.blur),
+            input: wrap('update-field', oldOn.input, true)
+          };
         }
         if (config.languageKey) {
           methods.mergeOptions({

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -497,7 +497,11 @@ export default defineComponent({
         // eslint-disable-next-line no-console
         console.log('[fc-designer emit]', name, payload);
         if (name === 'update-field') {
-          const key = payload && ((payload.id || payload.field) + (payload.row ? ':' + payload.row : ''));
+          const key =
+            payload &&
+            ((payload.id && payload.field)
+              ? payload.id + ':' + payload.field
+              : payload.id || payload.field);
           clearTimeout(timers[key]);
           timers[key] = setTimeout(() => {
             vm.emit(name, payload);
@@ -1838,14 +1842,15 @@ export default defineComponent({
               typeof handler === 'function'
                 ? `(${handler.toString()}).apply(this, arguments);`
                 : '';
-            const valueAssign = withVal
-              ? 'payload.value = arguments[0];'
-              : '';
+            const valueAssign = withVal ? 'payload.value = arguments[0];\n' : '';
+            const rowConst =
+              rule._fc_table_row !== undefined
+                ? JSON.stringify(rule._fc_table_row)
+                : null;
+            const idExpr = rowConst !== null ? rowConst : idConst;
             const body =
-              `var row = this.rule && this.rule._fc_table_row;\n` +
-              `var payload = {id: row !== undefined ? row : ${idConst}, field: ${fieldConst}};\n` +
-              `if (row !== undefined) payload.row = row;\n` +
-              `${valueAssign}\n` +
+              `var payload = {id: ${idExpr}, field: ${fieldConst}};\n` +
+              valueAssign +
               `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', payload);` +
               (handlerStr ? `\n${handlerStr}` : '');
             return new Function(body);

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -723,9 +723,6 @@ export default {
                 return;
             }
             const tr = this.formCreateInject.form.parseJson(this.copyTrs)[0];
-            if (!tr._fc_row_id) {
-                tr._fc_row_id = uniqueId();
-            }
             if (this.trs.length === 1 && this.trs[0]._isEmpty) {
                 this.trs.splice(0, 1);
             }
@@ -738,7 +735,10 @@ export default {
         },
         updateRaw(tr) {
             const idx = this.trs.indexOf(tr);
-            const rowId = tr._fc_row_id || uniqueId();
+            const tableField =
+                (this.formCreateInject && (this.formCreateInject.field || (this.formCreateInject.rule && this.formCreateInject.rule.field)))
+                || this.$attrs.field;
+            const rowId = tableField ? `${tableField}_${idx}` : (tr._fc_row_id || uniqueId());
             tr._fc_row_id = rowId;
             const markRow = (rules) => {
                 (rules || []).forEach(r => {

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -743,8 +743,10 @@ export default {
             const markRow = (rules) => {
                 (rules || []).forEach(r => {
                     r._fc_table_row = rowId;
-                    if (r.on && (r.on.focus || r.on.blur || r.on.input)) {
-                        const oldOn = r.on;
+                    if ((r._fc_on || r.on) && ((r._fc_on || r.on).focus || (r._fc_on || r.on).blur || (r._fc_on || r.on).input)) {
+                        const oldOn = r._fc_on || r.on;
+                        // preserve original handlers for future wraps
+                        r._fc_on = oldOn;
                         const fieldConst = JSON.stringify(r.field);
                         const idConst = JSON.stringify(rowId);
                         const wrap = (eventName, handler, withVal) => {

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -743,6 +743,30 @@ export default {
             const markRow = (rules) => {
                 (rules || []).forEach(r => {
                     r._fc_table_row = rowId;
+                    if (r.on && (r.on.focus || r.on.blur || r.on.input)) {
+                        const oldOn = r.on;
+                        const fieldConst = JSON.stringify(r.field);
+                        const idConst = JSON.stringify(rowId);
+                        const wrap = (eventName, handler, withVal) => {
+                            const handlerStr =
+                                typeof handler === 'function'
+                                    ? `(${handler.toString()}).apply(this, arguments);`
+                                    : '';
+                            const valueAssign = withVal ? 'payload.value = arguments[0];\n' : '';
+                            const body =
+                                `var payload = {id: ${idConst}, field: ${fieldConst}};\n` +
+                                valueAssign +
+                                `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', payload);` +
+                                (handlerStr ? `\n${handlerStr}` : '');
+                            return new Function(body);
+                        };
+                        r.on = {
+                            ...oldOn,
+                            focus: wrap('focus-field', oldOn.focus),
+                            blur: wrap('blur-field', oldOn.blur),
+                            input: wrap('update-field', oldOn.input, true)
+                        };
+                    }
                     if (Array.isArray(r.children)) {
                         markRow(r.children);
                     }

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -743,32 +743,6 @@ export default {
             const markRow = (rules) => {
                 (rules || []).forEach(r => {
                     r._fc_table_row = rowId;
-                    if ((r._fc_on || r.on) && ((r._fc_on || r.on).focus || (r._fc_on || r.on).blur || (r._fc_on || r.on).input)) {
-                        const oldOn = r._fc_on || r.on;
-                        // preserve original handlers for future wraps
-                        r._fc_on = oldOn;
-                        const fieldConst = JSON.stringify(r.field);
-                        const idConst = JSON.stringify(rowId);
-                        const wrap = (eventName, handler, withVal) => {
-                            const handlerStr =
-                                typeof handler === 'function'
-                                    ? `(${handler.toString()}).apply(this, arguments);`
-                                    : '';
-                            const valueAssign = withVal ? 'payload.value = arguments[0];\n' : '';
-                            const body =
-                                `var payload = {id: ${idConst}, field: ${fieldConst}};\n` +
-                                valueAssign +
-                                `window.__FC_DESIGNER_EMIT__ && window.__FC_DESIGNER_EMIT__('${eventName}', payload);` +
-                                (handlerStr ? `\n${handlerStr}` : '');
-                            return new Function(body);
-                        };
-                        r.on = {
-                            ...oldOn,
-                            focus: wrap('focus-field', oldOn.focus),
-                            blur: wrap('blur-field', oldOn.blur),
-                            input: wrap('update-field', oldOn.input, true)
-                        };
-                    }
                     if (Array.isArray(r.children)) {
                         markRow(r.children);
                     }

--- a/packages/element-ui/src/components/tableForm/TableForm.vue
+++ b/packages/element-ui/src/components/tableForm/TableForm.vue
@@ -43,6 +43,7 @@
 import {markRaw, reactive} from 'vue';
 import ImportSteps from '../import/ImportSteps.vue';
 import * as XLSX from 'xlsx';
+import uniqueId from '@form-create/utils/lib/unique';
 
 export default {
     name: 'TableForm',
@@ -628,6 +629,16 @@ export default {
             const raw = this.trs[idx];
             this.fapi.setChildrenFormData(raw, formData, true);
         },
+        setFieldByRow(rowId, field, value) {
+            const idx = this.trs.findIndex(tr => tr._fc_row_id === rowId);
+            if (idx === -1) {
+                return;
+            }
+            const data = this.fapi.getChildrenFormData(this.trs[idx]);
+            data[field] = value;
+            this.setRawData(idx, data);
+            this.updateValue();
+        },
         updateTable() {
             try {
                 // 更新内部 modelValue 副本，处理不同类型的数据
@@ -712,6 +723,9 @@ export default {
                 return;
             }
             const tr = this.formCreateInject.form.parseJson(this.copyTrs)[0];
+            if (!tr._fc_row_id) {
+                tr._fc_row_id = uniqueId();
+            }
             if (this.trs.length === 1 && this.trs[0]._isEmpty) {
                 this.trs.splice(0, 1);
             }
@@ -724,6 +738,17 @@ export default {
         },
         updateRaw(tr) {
             const idx = this.trs.indexOf(tr);
+            const rowId = tr._fc_row_id || uniqueId();
+            tr._fc_row_id = rowId;
+            const markRow = (rules) => {
+                (rules || []).forEach(r => {
+                    r._fc_table_row = rowId;
+                    if (Array.isArray(r.children)) {
+                        markRow(r.children);
+                    }
+                });
+            };
+            markRow(tr.children);
             tr.children[0].props.innerText = idx + 1;
             tr.children[tr.children.length - 1].children[0].props.onClick = () => {
                 this.delRaw(idx);


### PR DESCRIPTION
## Summary
- expose `editing` prop and forward focus/blur/input events for collaborative edits
- inject collaborative state to show editing user badges on drag items
- use global `__FC_DESIGNER_EMIT__` to forward field events without relying on local scope
- embed field id directly into serialized event handlers to prevent `rule` reference errors
- log collaborative event emissions and state updates for debugging
- debounce `update-field` emissions and include unique rule ids for disambiguating table form cells
- tag table-form rows with persistent ids and include row key in collaborative event payloads
- add `setFieldByRow` helper to update table-form cells by row id
- ensure every collaborative event payload includes a stable field id even when rule metadata is missing
- read row id from component rule at runtime so events from identical columns in different rows can be distinguished

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_b_68c14577c9b883228d2a4fb44619ed9c