### PR TITLE
feat: expose field editing events

### DIFF
--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -1,59 +1,64 @@
 <script>
-import {defineComponent, h} from 'vue';
+import {defineComponent, h, inject, useAttrs} from 'vue';
 import draggable from 'vuedraggable/src/vuedraggable';
 
 export default defineComponent({
     name: 'DragBox',
     props: ['rule', 'tag', 'formCreateInject', 'list'],
-    render(ctx) {
-        const attrs = {...ctx.$props.rule.props, ...ctx.$attrs};
-        let _class = '_fd-' + ctx.$props.tag + '-drag _fd-drag-box';
-        if (!Object.keys(ctx.$slots).length) {
-            _class += ' drag-holder';
-        }
-        attrs.class = _class;
-        attrs.modelValue = ctx.$props.list || [...ctx.$props.formCreateInject.children];
-
-        const keys = {};
-        if (ctx.$slots.default) {
-            const children = ctx.$slots.default();
-            children.forEach(v => {
-                if (v.key) {
-                    keys[v.key] = v;
-                }
-            })
-        }
-        return h(draggable, attrs, {
-            item: ({element, index}) => {
-                const key = element?.__fc__?.key;
-                if (key) {
-                    let vnode = keys['_' + element.slot];
-                    if (vnode) {
-                        vnode.children.forEach(v => {
-                            if (v.key === key + 'fc') {
-                                vnode = v
-                            }
-                        });
-                    } else {
-                        vnode = keys[key + 'fc'];
-                    }
-                    if (vnode) {
-                        const children = [vnode];
-                        if (element && Array.isArray(element.unames) && element.unames.length) {
-                            children.push(
-                                h('div', {class: '_fc-editing-users'}, element.unames.map(n => h('span', {class: '_fc-user'}, n)))
-                            );
-                        }
-                        return h('div', {
-                            class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item',
-                            key,
-                            style: element && element.unames && element.unames.length ? {position: 'relative'} : undefined
-                        }, children);
-                    }
-                }
-                return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key: index}, null);
+    setup(props, {slots}) {
+        const attrs = useAttrs();
+        const collabState = inject('collabState', {});
+        return () => {
+            const dragAttrs = {...props.rule.props, ...attrs};
+            let _class = '_fd-' + props.tag + '-drag _fd-drag-box';
+            if (!slots.default) {
+                _class += ' drag-holder';
             }
-        });
+            dragAttrs.class = _class;
+            dragAttrs.modelValue = props.list || [...props.formCreateInject.children];
+
+            const keys = {};
+            if (slots.default) {
+                const children = slots.default();
+                children.forEach(v => {
+                    if (v.key) {
+                        keys[v.key] = v;
+                    }
+                });
+            }
+            return h(draggable, dragAttrs, {
+                item: ({element, index}) => {
+                    const key = element?.__fc__?.key;
+                    if (key) {
+                        let vnode = keys['_' + element.slot];
+                        if (vnode) {
+                            vnode.children.forEach(v => {
+                                if (v.key === key + 'fc') {
+                                    vnode = v;
+                                }
+                            });
+                        } else {
+                            vnode = keys[key + 'fc'];
+                        }
+                        if (vnode) {
+                            const unames = collabState && element ? collabState[element.field] || element.unames : undefined;
+                            const children = [vnode];
+                            if (unames && Array.isArray(unames) && unames.length) {
+                                children.push(
+                                    h('div', {class: '_fc-editing-users'}, unames.map(n => h('span', {class: '_fc-user'}, n)))
+                                );
+                            }
+                            return h('div', {
+                                class: '_fc-' + props.tag + '-item _fd-drag-item',
+                                key,
+                                style: unames && unames.length ? {position: 'relative'} : undefined
+                            }, children);
+                        }
+                    }
+                    return h('div', {class: '_fc-' + props.tag + '-item _fd-drag-item', key: index}, null);
+                }
+            });
+        };
     }
 });
 </script>

--- a/packages/element-ui/src/components/DragBox.vue
+++ b/packages/element-ui/src/components/DragBox.vue
@@ -38,7 +38,17 @@ export default defineComponent({
                         vnode = keys[key + 'fc'];
                     }
                     if (vnode) {
-                        return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key}, vnode);
+                        const children = [vnode];
+                        if (element && Array.isArray(element.unames) && element.unames.length) {
+                            children.push(
+                                h('div', {class: '_fc-editing-users'}, element.unames.map(n => h('span', {class: '_fc-user'}, n)))
+                            );
+                        }
+                        return h('div', {
+                            class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item',
+                            key,
+                            style: element && element.unames && element.unames.length ? {position: 'relative'} : undefined
+                        }, children);
                     }
                 }
                 return h('div', {class: '_fc-' + ctx.$props.tag + '-item _fd-drag-item', key: index}, null);

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -491,6 +491,10 @@ export default defineComponent({
     provide('fcx', fcx);
     provide('designer', vm);
 
+    const globalBus = typeof window !== 'undefined'
+      ? (window.__FC_DESIGNER_EMIT__ = window.__FC_DESIGNER_EMIT__ || Mitt())
+      : Mitt();
+
     // collaborative editing state
     const collabState = reactive(editing.value || {});
     watch(editing, (val) => {
@@ -839,6 +843,7 @@ export default defineComponent({
         if (evt) {
           vm.emit(evt, payload);
           console.log('[fc-designer emit]', evt, payload);
+          globalBus.emit(evt, payload);
         }
       },
       makeChildren(children) {

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -480,15 +480,26 @@ export default defineComponent({
       default: undefined,
     },
     locale: Object,
-    handle: Array
+    handle: Array,
+    editing: Object
   },
   emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice', 'focus-field', 'blur-field', 'update-field'],
   setup(props) {
-    const {menu, height, mask, locale, handle} = toRefs(props);
+    const {menu, height, mask, locale, handle, editing} = toRefs(props);
     const vm = getCurrentInstance();
     const fcx = reactive({active: null});
     provide('fcx', fcx);
     provide('designer', vm);
+
+    // collaborative editing state
+    const collabState = reactive(editing.value || {});
+    watch(editing, (val) => {
+      Object.keys(collabState).forEach(k => delete collabState[k]);
+      Object.assign(collabState, val || {});
+      // eslint-disable-next-line no-console
+      console.log('[fc-designer editing]', collabState);
+    });
+    provide('collabState', collabState);
 
     const configRef = toRef(props, 'config', {});
     const baseRule = toRef(configRef.value, 'baseRule', null);

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -380,7 +380,7 @@
           </div>
           <template v-if="previewStatus === 'form'">
             <ViewForm :rule="preview.rule" :option="preview.option" v-model:api="preview.api"
-                      v-if="preview.state">
+                      v-if="preview.state" @emit-event="emitFieldEvent">
               <template v-for="(_, name) in $slots" #[name]="scope">
                 <slot :name="name" v-bind="scope ?? {}"/>
               </template>
@@ -1018,6 +1018,8 @@ export default defineComponent({
         const options = methods.getOptionsJson();
         data.preview.rule = designerForm.parseJson(rule);
         data.preview.option = designerForm.parseJson(options);
+        // enable emit-event for focus, blur and input events in preview
+        data.preview.option.emit = ['focus', 'blur', 'input', 'change'];
         const useV2 = methods.getConfig('useTemplate', false);
         data.preview.component = hljs.highlight(
             useV2 ? formTemplate(rule, options) : formTemplateV3(rule, options),

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -210,7 +210,8 @@
                  :style="{'--fc-drag-empty': `'${t('designer.dragEmpty')}'`,'--fc-child-empty': `'${t('designer.childEmpty')}'`}">
               <div class="_fc-m-input" v-if="inputForm.state">
                 <ViewForm :key="inputForm.key" :rule="inputForm.rule" :option="inputForm.option"
-                          v-model:api="inputForm.api" :disabled="false"></ViewForm>
+                          v-model:api="inputForm.api" :disabled="false"
+                          @emit-event="emitFieldEvent"></ViewForm>
               </div>
               <DragForm v-else :rule="dragForm.rule" :option="formOptions"
                         v-model:api="dragForm.api"></DragForm>
@@ -807,6 +808,28 @@ export default defineComponent({
           n && methods.updateRuleFormData()
         }, {deep: true, flush: 'post'});
       },
+      // emit field events for collaboration
+      emitFieldEvent(name, field, ...args) {
+        const value = args[0];
+        const payload = {field, value};
+        const match = field && String(field).match(/^([A-Za-z0-9_]+_\d+)_([A-Za-z0-9_]+)$/);
+        if (match) {
+          payload.id = match[1];
+          payload.field = match[2];
+        }
+        let evt = '';
+        if (name === 'focus') {
+          evt = 'focus-field';
+        } else if (name === 'blur') {
+          evt = 'blur-field';
+        } else if (name === 'input' || name === 'change') {
+          evt = 'update-field';
+        }
+        if (evt) {
+          vm.emit(evt, payload);
+          console.log('[fc-designer emit]', evt, payload);
+        }
+      },
       makeChildren(children) {
         return reactive({children}).children;
       },
@@ -880,6 +903,8 @@ export default defineComponent({
           data.inputForm.option.appendValue = false;
           data.inputForm.option.submitBtn.show = false;
           data.inputForm.option.resetBtn.show = false;
+          // enable emit-event for focus, blur and input events
+          data.inputForm.option.emit = ['focus', 'blur', 'input', 'change'];
           methods.clearActiveRule();
         }
       },

--- a/packages/element-ui/src/components/FcDesigner.vue
+++ b/packages/element-ui/src/components/FcDesigner.vue
@@ -482,7 +482,7 @@ export default defineComponent({
     locale: Object,
     handle: Array
   },
-  emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice'],
+  emits: ['active', 'create', 'copy', 'delete', 'drag', 'inputData', 'save', 'clear', 'copyRule', 'pasteRule', 'sortUp', 'sortDown', 'changeDevice', 'focus-field', 'blur-field', 'update-field'],
   setup(props) {
     const {menu, height, mask, locale, handle} = toRefs(props);
     const vm = getCurrentInstance();

--- a/packages/element-ui/src/style/index.css
+++ b/packages/element-ui/src/style/index.css
@@ -757,3 +757,21 @@
 .CodeMirror-hints {
     z-index: 999999;
 }
+
+/* collaborative editing indicator styles */
+._fc-editing-users {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    background: rgba(255,255,255,0.9);
+    border: 1px solid #e5e5e5;
+    border-radius: 2px;
+    padding: 0 4px;
+    font-size: 12px;
+    line-height: 1.2;
+    z-index: 10;
+    pointer-events: none;
+}
+._fc-editing-users ._fc-user:not(:last-child) {
+    margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- emit field focus, blur and value updates for collaboration
- display collaborator names on drag items
- add styles for collaborative editing indicators
- log collaboration event names and payloads for debugging

## Testing
- `pnpm run build` *(fails: lerna not found)*
- `pnpm add -g lerna` *(fails: Unable to find the global bin directory)*
- `npx lerna run build` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68c248b928a08322b9d589f73ec26d54